### PR TITLE
Support for matrix parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.virtualenv
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+*.prof
+*.aux
+*.hp

--- a/servant-server.cabal
+++ b/servant-server.cabal
@@ -42,7 +42,7 @@ library
     , http-types
     , network-uri >= 2.6
     , safe
-    , servant >= 0.2
+    , servant >= 0.2.2
     , split
     , string-conversions
     , system-filepath

--- a/servant-server.cabal
+++ b/servant-server.cabal
@@ -1,5 +1,5 @@
 name:                servant-server
-version:             0.2.3
+version:             0.2.4
 synopsis:            A family of combinators for defining webservices APIs and serving them
 description:
   A family of combinators for defining webservices APIs and serving them

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -18,14 +18,15 @@ import Data.Monoid (Monoid, mempty, mappend)
 import Data.Proxy (Proxy(Proxy))
 import Data.String (fromString)
 import Data.String.Conversions (cs, (<>))
-import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Text (Text)
+import qualified Data.Text as T
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Network.HTTP.Types hiding (Header)
 import Network.Wai (Response, Request, ResponseReceived, Application, pathInfo, requestBody,
                     strictRequestBody, lazyRequestBody, requestHeaders, requestMethod,
                     rawQueryString, responseLBS)
-import Servant.API (QueryParams, QueryParam, QueryFlag, ReqBody, Header, Capture, Get, Delete, Put, Post, Raw, (:>), (:<|>)(..))
+import Servant.API (QueryParams, QueryParam, QueryFlag, MatrixParams, MatrixParam, MatrixFlag, ReqBody, Header, Capture, Get, Delete, Put, Post, Raw, (:>), (:<|>)(..))
 import Servant.Common.Text (FromText, fromText)
 
 data ReqBodyState = Uncalled
@@ -132,10 +133,16 @@ type RoutingApplication =
 class HasServer layout where
   type Server layout :: *
   route :: Proxy layout -> Server layout -> RoutingApplication
+  -- Remove matrix parameters from the head of the pathinfo if
+  -- we're done parsing them. Couldn't find a nicer way...
+  maybeStripMatrix :: Proxy layout -> Text -> [Text] -> [Text]
+  maybeStripMatrix Proxy first rest
+    | ";" `T.isPrefixOf` first = rest
+    | otherwise                = first : rest
 
 -- * Instances
 
--- | A server for @a ':<|>' b@ first tries to match the request again the route
+-- | A server for @a ':<|>' b@ first tries to match the request against the route
 --   represented by @a@ and if it fails tries @b@. You must provide a request
 --   handler for each route.
 --
@@ -441,6 +448,139 @@ instance (KnownSymbol sym, HasServer sublayout)
           examine v | v == "true" || v == "1" || v == "" = True
                     | otherwise = False
 
+parseMatrixText = parseQueryText
+
+-- | If you use @'MatrixParam' "author" Text@ in one of the endpoints for your API,
+-- this automatically requires your server-side handler to be a function
+-- that takes an argument of type @'Maybe' 'Text'@.
+--
+-- This lets servant worry about looking it up in the query string
+-- and turning it into a value of the type you specify, enclosed
+-- in 'Maybe', because it may not be there and servant would then
+-- hand you 'Nothing'.
+--
+-- You can control how it'll be converted from 'Text' to your type
+-- by simply providing an instance of 'FromText' for your type.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixParam "author" Text :> Get [Book]
+-- >
+-- > server :: Server MyApi
+-- > server = getBooksBy
+-- >   where getBooksBy :: Maybe Text -> EitherT (Int, String) IO [Book]
+-- >         getBooksBy Nothing       = ...return all books...
+-- >         getBooksBy (Just author) = ...return books by the given author...
+instance (KnownSymbol sym, FromText a, HasServer sublayout)
+      => HasServer (MatrixParam sym a :> sublayout) where
+
+  type Server (MatrixParam sym a :> sublayout) =
+    Maybe a -> Server sublayout
+
+  route Proxy subserver request respond = case pathInfo request of
+    (first : rest)
+      -> do let querytext = parseMatrixText . encodeUtf8 $ T.tail first
+                param = case lookup paramname querytext of
+                  Nothing       -> Nothing -- param absent from the query string
+                  Just Nothing  -> Nothing -- param present with no value -> Nothing
+                  Just (Just v) -> fromText v -- if present, we try to convert to
+                                        -- the right type
+            route (Proxy :: Proxy sublayout) (subserver param) request{
+                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+            } respond
+    _ -> route (Proxy :: Proxy sublayout) (subserver Nothing) request respond
+
+    where paramname = cs $ symbolVal (Proxy :: Proxy sym)
+
+  -- Don't consume the path if a matrix parameter follows a matrix parameter
+  -- and 'first' contains a matrix parameter
+  maybeStripMatrix Proxy first rest = first : rest
+
+-- | If you use @'MatrixParams' "authors" Text@ in one of the endpoints for your API,
+-- this automatically requires your server-side handler to be a function
+-- that takes an argument of type @['Text']@.
+--
+-- This lets servant worry about looking up 0 or more values in the query string
+-- associated to @authors@ and turning each of them into a value of
+-- the type you specify.
+--
+-- You can control how the individual values are converted from 'Text' to your type
+-- by simply providing an instance of 'FromText' for your type.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixParams "authors" Text :> Get [Book]
+-- >
+-- > server :: Server MyApi
+-- > server = getBooksBy
+-- >   where getBooksBy :: [Text] -> EitherT (Int, String) IO [Book]
+-- >         getBooksBy authors = ...return all books by these authors...
+instance (KnownSymbol sym, FromText a, HasServer sublayout)
+      => HasServer (MatrixParams sym a :> sublayout) where
+
+  type Server (MatrixParams sym a :> sublayout) =
+    [a] -> Server sublayout
+
+  route Proxy subserver request respond = case pathInfo request of
+    (first : rest)
+      -> do let matrixtext = parseMatrixText . encodeUtf8 $ T.tail first
+                -- if sym is "foo", we look for matrix parameters
+                -- named "foo" or "foo[]" and call fromText on the
+                -- corresponding values
+                parameters = filter looksLikeParam matrixtext
+                values = catMaybes $ map (convert . snd) parameters
+            route (Proxy :: Proxy sublayout) (subserver values) request{
+                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+            } respond
+    _ -> route (Proxy :: Proxy sublayout) (subserver []) request respond
+
+    where paramname = cs $ symbolVal (Proxy :: Proxy sym)
+          looksLikeParam (name, _) = name == paramname || name == (paramname <> "[]")
+          convert Nothing = Nothing
+          convert (Just v) = fromText v
+
+  -- Don't consume the path if a matrix parameter follows a matrix parameter
+  maybeStripMatrix Proxy first rest = first : rest
+
+-- | If you use @'MatrixFlag' "published"@ in one of the endpoints for your API,
+-- this automatically requires your server-side handler to be a function
+-- that takes an argument of type 'Bool'.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixFlag "published" :> Get [Book]
+-- >
+-- > server :: Server MyApi
+-- > server = getBooks
+-- >   where getBooks :: Bool -> EitherT (Int, String) IO [Book]
+-- >         getBooks onlyPublished = ...return all books, or only the ones that are already published, depending on the argument...
+instance (KnownSymbol sym, HasServer sublayout)
+      => HasServer (MatrixFlag sym :> sublayout) where
+
+  type Server (MatrixFlag sym :> sublayout) =
+    Bool -> Server sublayout
+
+  route Proxy subserver request respond =  case pathInfo request of
+    (first : rest)
+      -> do let matrixtext = parseMatrixText . encodeUtf8 $ T.tail first
+                param = case lookup paramname matrixtext of
+                  Just Nothing  -> True  -- param is there, with no value
+                  Just (Just v) -> examine v -- param with a value
+                  Nothing       -> False -- param not in the query string
+
+            route (Proxy :: Proxy sublayout) (subserver param) request{
+                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+            } respond
+
+    _ -> route (Proxy :: Proxy sublayout) (subserver False) request respond
+
+    where paramname = cs $ symbolVal (Proxy :: Proxy sym)
+          examine v | v == "true" || v == "1" || v == "" = True
+                    | otherwise = False
+
+  -- Don't consume the path if a matrix parameter follows a matrix parameter
+  maybeStripMatrix Proxy first rest = first : rest
+
 -- | Just pass the request to the underlying application and serve its response.
 --
 -- Example:
@@ -488,10 +628,30 @@ instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout
   type Server (path :> sublayout) = Server sublayout
   route Proxy subserver request respond = case pathInfo request of
     (first : rest)
-      | first == cs (symbolVal proxyPath)
-      -> route (Proxy :: Proxy sublayout) subserver request{
-           pathInfo = rest
-         } respond
+      | parsePath first == cs (symbolVal proxyPath)
+      -> do
+        -- If the path segment contains matrix parameters, push
+        -- them back onto the pathinfo list
+        let mxParams = matrixParameters first
+            rest' = if T.null mxParams
+                    then rest
+                    else T.cons ';' mxParams : rest
+        route (Proxy :: Proxy sublayout) subserver request{
+          pathInfo = rest'
+        } respond
     _ -> respond $ failWith NotFound
 
     where proxyPath = Proxy :: Proxy path
+          parsePath = fst . splitMatrixParameters
+          matrixParameters = snd . splitMatrixParameters
+
+splitAtFirst :: (Char -> Bool) -> Text -> (Text, Text)
+splitAtFirst p = snd . split'
+    where split' = T.foldl' step (False, (T.empty, T.empty))
+          step (False, (a, b)) c | p c     = (True, (a, b))
+                               | otherwise = (False, (T.snoc a c, b))
+          step (True, (a, b))  c           = (True, (a, T.snoc b c))
+
+splitMatrixParameters :: Text -> (Text, Text)
+splitMatrixParameters = splitAtFirst (== ';')
+

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -13,6 +13,7 @@ import Data.Aeson (ToJSON, FromJSON, encode, decode')
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.List (unfoldr)
 import Data.Maybe (catMaybes)
 import Data.Monoid (Monoid, mempty, mappend)
 import Data.Proxy (Proxy(Proxy))
@@ -109,7 +110,7 @@ isMismatch _             = False
 
 -- | Like `null . pathInfo`, but works with redundant trailing slashes.
 pathIsEmpty :: Request -> Bool
-pathIsEmpty = f . pathInfo
+pathIsEmpty = f . processedPathInfo
   where
     f []   = True
     f [""] = True
@@ -130,26 +131,31 @@ type RoutingApplication =
      Request -- ^ the request, the field 'pathInfo' may be modified by url routing
   -> (RouteResult Response -> IO ResponseReceived) -> IO ResponseReceived
 
+splitMatrixParameters :: Text -> (Text, Text)
+splitMatrixParameters = T.break (== ';')
+
+parsePathInfo :: Request -> [Text]
+parsePathInfo = filter (/= "") . mergePairs . map splitMatrixParameters . pathInfo
+  where mergePairs = concat . unfoldr pairToList
+        pairToList []          = Nothing
+        pairToList ((a, b):xs) = Just ([a, b], xs)
+
+-- | Returns a processed pathInfo from the request.
+--
+-- In order to handle matrix parameters in the request correctly, the raw pathInfo needs to be
+-- processed, so routing works as intended. Therefor this function should be used to access
+-- the pathInfo for routing purposes.
+processedPathInfo :: Request -> [Text]
+processedPathInfo r =
+  case pinfo of
+    (x:xs) | T.head x == ';' -> xs
+    _                        -> pinfo
+  where pinfo = parsePathInfo r
+
 class HasServer layout where
   type Server layout :: *
   route :: Proxy layout -> Server layout -> RoutingApplication
 
-  -- | Possibly push matrix parameters back into the pathinfo list.
-  --
-  -- If matrix parameters are found in this path segment, only
-  -- push them back onto the pathinfo list if the next type in
-  -- the route chain is some kind of matrix parameter
-  maybePushMatrix :: Proxy layout -> Text -> [Text] -> [Text]
-  maybePushMatrix Proxy _ rest = rest -- The default implementation always skips pushing matrix parameters
-
-  -- | Possibly pop matrix parameters from the pathinfo list.
-  -- 
-  -- Remove matrix parameters from the head of the pathinfo if
-  -- we're done parsing them (i.e. if 
-  maybePopMatrix :: Proxy layout -> Text -> [Text] -> [Text]
-  maybePopMatrix Proxy first rest
-    | ";" `T.isPrefixOf` first = rest
-    | otherwise                = first : rest
 
 -- * Instances
 
@@ -201,18 +207,16 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
   type Server (Capture capture a :> sublayout) =
      a -> Server sublayout
 
-  route Proxy subserver request respond = case pathInfo request of
+  route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
-      -> let (first', mxParams) = splitMatrixParameters first
-         in case captured captureProxy first' of
+      -> case captured captureProxy first of
            Nothing  -> respond $ failWith NotFound
            Just v   -> route (Proxy :: Proxy sublayout) (subserver v) request{
-                         pathInfo = maybePushMatrix sublayoutProxy mxParams rest
+                         pathInfo = rest
                        } respond
     _ -> respond $ failWith NotFound
 
     where captureProxy = Proxy :: Proxy (Capture capture a)
-          sublayoutProxy = Proxy :: Proxy sublayout
            
 
 -- | If you have a 'Delete' endpoint in your API,
@@ -492,29 +496,19 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
   type Server (MatrixParam sym a :> sublayout) =
     Maybe a -> Server sublayout
 
-  route Proxy subserver request respond = case pathInfo request of
-    (first : rest)
+  route Proxy subserver request respond = case parsePathInfo request of
+    (first : _)
       -> do let querytext = parseMatrixText . encodeUtf8 $ T.tail first
                 param = case lookup paramname querytext of
                   Nothing       -> Nothing -- param absent from the query string
                   Just Nothing  -> Nothing -- param present with no value -> Nothing
                   Just (Just v) -> fromText v -- if present, we try to convert to
                                         -- the right type
-            route (Proxy :: Proxy sublayout) (subserver param) request{
-                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
-            } respond
+            putStrLn $ "matrix param " ++ T.unpack paramname ++ " has value " ++ show (fmap (fmap T.unpack) (lookup paramname querytext))
+            route (Proxy :: Proxy sublayout) (subserver param) request respond
     _ -> route (Proxy :: Proxy sublayout) (subserver Nothing) request respond
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
-
-  maybePushMatrix Proxy first rest
-    -- Make sure the parent route keeps the matrix parameters
-    | T.null first = rest
-    | otherwise    = T.cons ';' first : rest
-
-  -- Don't consume the path if a matrix parameter follows a matrix parameter
-  -- and 'first' contains a matrix parameter
-  maybePopMatrix Proxy first rest = first : rest
 
 
 -- | If you use @'MatrixParams' "authors" Text@ in one of the endpoints for your API,
@@ -542,31 +536,21 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
   type Server (MatrixParams sym a :> sublayout) =
     [a] -> Server sublayout
 
-  route Proxy subserver request respond = case pathInfo request of
-    (first : rest)
+  route Proxy subserver request respond = case parsePathInfo request of
+    (first : _)
       -> do let matrixtext = parseMatrixText . encodeUtf8 $ T.tail first
                 -- if sym is "foo", we look for matrix parameters
                 -- named "foo" or "foo[]" and call fromText on the
                 -- corresponding values
                 parameters = filter looksLikeParam matrixtext
                 values = catMaybes $ map (convert . snd) parameters
-            route (Proxy :: Proxy sublayout) (subserver values) request{
-                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
-            } respond
+            route (Proxy :: Proxy sublayout) (subserver values) request respond
     _ -> route (Proxy :: Proxy sublayout) (subserver []) request respond
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
           looksLikeParam (name, _) = name == paramname || name == (paramname <> "[]")
           convert Nothing = Nothing
           convert (Just v) = fromText v
-
-  maybePushMatrix Proxy first rest
-    -- Make sure the parent route keeps the matrix parameters
-    | T.null first = rest
-    | otherwise    = T.cons ';' first : rest
-
-  -- Don't consume the path if a matrix parameter follows a matrix parameter
-  maybePopMatrix Proxy first rest = first : rest
 
 
 -- | If you use @'MatrixFlag' "published"@ in one of the endpoints for your API,
@@ -587,32 +571,21 @@ instance (KnownSymbol sym, HasServer sublayout)
   type Server (MatrixFlag sym :> sublayout) =
     Bool -> Server sublayout
 
-  route Proxy subserver request respond =  case pathInfo request of
-    (first : rest)
+  route Proxy subserver request respond =  case parsePathInfo request of
+    (first : _)
       -> do let matrixtext = parseMatrixText . encodeUtf8 $ T.tail first
                 param = case lookup paramname matrixtext of
                   Just Nothing  -> True  -- param is there, with no value
                   Just (Just v) -> examine v -- param with a value
                   Nothing       -> False -- param not in the query string
 
-            route (Proxy :: Proxy sublayout) (subserver param) request{
-                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
-            } respond
+            route (Proxy :: Proxy sublayout) (subserver param) request respond
 
     _ -> route (Proxy :: Proxy sublayout) (subserver False) request respond
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
           examine v | v == "true" || v == "1" || v == "" = True
                     | otherwise = False
-
-  maybePushMatrix Proxy first rest
-    -- Make sure the parent route keeps the matrix parameters
-    | T.null first = rest
-    | otherwise    = T.cons ';' first : rest
-
-  -- Don't consume the path if a matrix parameter follows a matrix parameter
-  maybePopMatrix Proxy first rest = first : rest
-
 
 -- | Just pass the request to the underlying application and serve its response.
 --
@@ -659,27 +632,16 @@ instance (FromJSON a, HasServer sublayout)
 -- pass the rest of the request path to @sublayout@.
 instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout) where
   type Server (path :> sublayout) = Server sublayout
-  route Proxy subserver request respond = case pathInfo request of
+  route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
-      | getPath first == cs (symbolVal proxyPath)
-      -> route sublayoutProxy subserver request{
-           pathInfo = maybePushMatrix sublayoutProxy (getMxParams first) rest
+      | first == cs (symbolVal proxyPath)
+      -> do
+        putStrLn $ "routing " ++ symbolVal (Proxy :: Proxy path)
+        putStrLn . show $ pathInfo request
+        putStrLn . show $ processedPathInfo request
+        route (Proxy :: Proxy sublayout) subserver request{
+           pathInfo = rest
          } respond
     _ -> respond $ failWith NotFound
 
     where proxyPath = Proxy :: Proxy path
-          sublayoutProxy = Proxy :: Proxy sublayout
-          getPath = fst . splitMatrixParameters
-          getMxParams = snd . splitMatrixParameters
-
-
-splitAtFirst :: (Char -> Bool) -> Text -> (Text, Text)
-splitAtFirst p = snd . split'
-    where split' = T.foldl' step (False, (T.empty, T.empty))
-          step (False, (a, b)) c | p c       = (True, (a, b))
-                                 | otherwise = (False, (T.snoc a c, b))
-          step (True, (a, b))  c             = (True, (a, T.snoc b c))
-
-splitMatrixParameters :: Text -> (Text, Text)
-splitMatrixParameters = splitAtFirst (== ';')
-

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -504,7 +504,6 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
                   Just Nothing  -> Nothing -- param present with no value -> Nothing
                   Just (Just v) -> fromText v -- if present, we try to convert to
                                         -- the right type
-            putStrLn $ "matrix param " ++ T.unpack paramname ++ " has value " ++ show (fmap (fmap T.unpack) (lookup paramname querytext))
             route (Proxy :: Proxy sublayout) (subserver param) request respond
     _ -> route (Proxy :: Proxy sublayout) (subserver Nothing) request respond
 
@@ -635,11 +634,7 @@ instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout
   route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
       | first == cs (symbolVal proxyPath)
-      -> do
-        putStrLn $ "routing " ++ symbolVal (Proxy :: Proxy path)
-        putStrLn . show $ pathInfo request
-        putStrLn . show $ processedPathInfo request
-        route (Proxy :: Proxy sublayout) subserver request{
+      -> route (Proxy :: Proxy sublayout) subserver request{
            pathInfo = rest
          } respond
     _ -> respond $ failWith NotFound

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -133,10 +133,21 @@ type RoutingApplication =
 class HasServer layout where
   type Server layout :: *
   route :: Proxy layout -> Server layout -> RoutingApplication
+
+  -- | Possibly push matrix parameters back into the pathinfo list.
+  --
+  -- If matrix parameters are found in this path segment, only
+  -- push them back onto the pathinfo list if the next type in
+  -- the route chain is some kind of matrix parameter
+  maybePushMatrix :: Proxy layout -> Text -> [Text] -> [Text]
+  maybePushMatrix Proxy _ rest = rest -- The default implementation always skips pushing matrix parameters
+
+  -- | Possibly pop matrix parameters from the pathinfo list.
+  -- 
   -- Remove matrix parameters from the head of the pathinfo if
-  -- we're done parsing them. Couldn't find a nicer way...
-  maybeStripMatrix :: Proxy layout -> Text -> [Text] -> [Text]
-  maybeStripMatrix Proxy first rest
+  -- we're done parsing them (i.e. if 
+  maybePopMatrix :: Proxy layout -> Text -> [Text] -> [Text]
+  maybePopMatrix Proxy first rest
     | ";" `T.isPrefixOf` first = rest
     | otherwise                = first : rest
 
@@ -193,17 +204,15 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
   route Proxy subserver request respond = case pathInfo request of
     (first : rest)
       -> let (first', mxParams) = splitMatrixParameters first
-             rest' = if T.null mxParams
-                     then rest
-                     else T.cons ';' mxParams : rest
          in case captured captureProxy first' of
            Nothing  -> respond $ failWith NotFound
            Just v   -> route (Proxy :: Proxy sublayout) (subserver v) request{
-                         pathInfo = rest'
+                         pathInfo = maybePushMatrix sublayoutProxy mxParams rest
                        } respond
     _ -> respond $ failWith NotFound
 
     where captureProxy = Proxy :: Proxy (Capture capture a)
+          sublayoutProxy = Proxy :: Proxy sublayout
            
 
 -- | If you have a 'Delete' endpoint in your API,
@@ -492,15 +501,21 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
                   Just (Just v) -> fromText v -- if present, we try to convert to
                                         -- the right type
             route (Proxy :: Proxy sublayout) (subserver param) request{
-                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
             } respond
     _ -> route (Proxy :: Proxy sublayout) (subserver Nothing) request respond
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
 
+  maybePushMatrix Proxy first rest
+    -- Make sure the parent route keeps the matrix parameters
+    | T.null first = rest
+    | otherwise    = T.cons ';' first : rest
+
   -- Don't consume the path if a matrix parameter follows a matrix parameter
   -- and 'first' contains a matrix parameter
-  maybeStripMatrix Proxy first rest = first : rest
+  maybePopMatrix Proxy first rest = first : rest
+
 
 -- | If you use @'MatrixParams' "authors" Text@ in one of the endpoints for your API,
 -- this automatically requires your server-side handler to be a function
@@ -536,7 +551,7 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
                 parameters = filter looksLikeParam matrixtext
                 values = catMaybes $ map (convert . snd) parameters
             route (Proxy :: Proxy sublayout) (subserver values) request{
-                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
             } respond
     _ -> route (Proxy :: Proxy sublayout) (subserver []) request respond
 
@@ -545,8 +560,14 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
           convert Nothing = Nothing
           convert (Just v) = fromText v
 
+  maybePushMatrix Proxy first rest
+    -- Make sure the parent route keeps the matrix parameters
+    | T.null first = rest
+    | otherwise    = T.cons ';' first : rest
+
   -- Don't consume the path if a matrix parameter follows a matrix parameter
-  maybeStripMatrix Proxy first rest = first : rest
+  maybePopMatrix Proxy first rest = first : rest
+
 
 -- | If you use @'MatrixFlag' "published"@ in one of the endpoints for your API,
 -- this automatically requires your server-side handler to be a function
@@ -575,7 +596,7 @@ instance (KnownSymbol sym, HasServer sublayout)
                   Nothing       -> False -- param not in the query string
 
             route (Proxy :: Proxy sublayout) (subserver param) request{
-                pathInfo = maybeStripMatrix (Proxy :: Proxy sublayout) first rest
+                pathInfo = maybePopMatrix (Proxy :: Proxy sublayout) first rest
             } respond
 
     _ -> route (Proxy :: Proxy sublayout) (subserver False) request respond
@@ -584,8 +605,14 @@ instance (KnownSymbol sym, HasServer sublayout)
           examine v | v == "true" || v == "1" || v == "" = True
                     | otherwise = False
 
+  maybePushMatrix Proxy first rest
+    -- Make sure the parent route keeps the matrix parameters
+    | T.null first = rest
+    | otherwise    = T.cons ';' first : rest
+
   -- Don't consume the path if a matrix parameter follows a matrix parameter
-  maybeStripMatrix Proxy first rest = first : rest
+  maybePopMatrix Proxy first rest = first : rest
+
 
 -- | Just pass the request to the underlying application and serve its response.
 --
@@ -634,29 +661,24 @@ instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout
   type Server (path :> sublayout) = Server sublayout
   route Proxy subserver request respond = case pathInfo request of
     (first : rest)
-      | parsePath first == cs (symbolVal proxyPath)
-      -> do
-        -- If the path segment contains matrix parameters, push
-        -- them back onto the pathinfo list
-        let mxParams = matrixParameters first
-            rest' = if T.null mxParams
-                    then rest
-                    else T.cons ';' mxParams : rest
-        route (Proxy :: Proxy sublayout) subserver request{
-          pathInfo = rest'
-        } respond
+      | getPath first == cs (symbolVal proxyPath)
+      -> route sublayoutProxy subserver request{
+           pathInfo = maybePushMatrix sublayoutProxy (getMxParams first) rest
+         } respond
     _ -> respond $ failWith NotFound
 
     where proxyPath = Proxy :: Proxy path
-          parsePath = fst . splitMatrixParameters
-          matrixParameters = snd . splitMatrixParameters
+          sublayoutProxy = Proxy :: Proxy sublayout
+          getPath = fst . splitMatrixParameters
+          getMxParams = snd . splitMatrixParameters
+
 
 splitAtFirst :: (Char -> Bool) -> Text -> (Text, Text)
 splitAtFirst p = snd . split'
     where split' = T.foldl' step (False, (T.empty, T.empty))
-          step (False, (a, b)) c | p c     = (True, (a, b))
-                               | otherwise = (False, (T.snoc a c, b))
-          step (True, (a, b))  c           = (True, (a, T.snoc b c))
+          step (False, (a, b)) c | p c       = (True, (a, b))
+                                 | otherwise = (False, (T.snoc a c, b))
+          step (True, (a, b))  c             = (True, (a, T.snoc b c))
 
 splitMatrixParameters :: Text -> (Text, Text)
 splitMatrixParameters = splitAtFirst (== ';')

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -448,6 +448,7 @@ instance (KnownSymbol sym, HasServer sublayout)
           examine v | v == "true" || v == "1" || v == "" = True
                     | otherwise = False
 
+parseMatrixText :: B.ByteString -> QueryText
 parseMatrixText = parseQueryText
 
 -- | If you use @'MatrixParam' "author" Text@ in one of the endpoints for your API,

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -192,14 +192,19 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
 
   route Proxy subserver request respond = case pathInfo request of
     (first : rest)
-      -> case captured captureProxy first of
+      -> let (first', mxParams) = splitMatrixParameters first
+             rest' = if T.null mxParams
+                     then rest
+                     else T.cons ';' mxParams : rest
+         in case captured captureProxy first' of
            Nothing  -> respond $ failWith NotFound
            Just v   -> route (Proxy :: Proxy sublayout) (subserver v) request{
-                         pathInfo = rest
+                         pathInfo = rest'
                        } respond
     _ -> respond $ failWith NotFound
 
     where captureProxy = Proxy :: Proxy (Capture capture a)
+           
 
 -- | If you have a 'Delete' endpoint in your API,
 -- the handler for this endpoint is meant to delete

--- a/test/Servant/ServerSpec.hs
+++ b/test/Servant/ServerSpec.hs
@@ -191,6 +191,17 @@ queryParamSpec = do
               name = "ALICE"
              }
 
+          let params3'' = "?unknown="
+          response3' <- Network.Wai.Test.request defaultRequest{
+            rawQueryString = params3'',
+            queryString = parseQuery params3'',
+            pathInfo = ["b"]
+           }
+          liftIO $
+            decode' (simpleBody response3') `shouldBe` Just alice{
+              name = "Alice"
+             }
+
 type MatrixParamApi = "a" :> MatrixParam "name" String :> Get Person
                 :<|> "b" :> MatrixParams "names" String :> "bsub" :> MatrixParams "names" String :> Get Person
                 :<|> "c" :> MatrixFlag "capitalize" :> Get Person


### PR DESCRIPTION
Added support for matrix parameters.

There's one ugly part here. The path segment in the incoming request will contain any matrix parameters in the string, e.g. "segment;foo=1;bar=baz". This means we can't simply pop the head of the pathinfo list as we route the request. If we find matrix parameters in the segment, and the sublayout starts with a matrix parameter type, we push the matrix parameters back to the pathinfo list (minus the path, i.e. ";foo=1;bar=baz" in the example above) before calling the recursive 'route'. In case there is no matrix parameters declared, we just ignore the parameters in the request (optionally we could fail here, but this would be inconsistent with how unknown query parameters work).

We finally pop off the matrix parameters (if there are any) from pathinfo in route for any type not related to matrix parameter parsing.

I solved this by adding two methods (maybe{Push,Pop}Matrix) to the type class HasServer. Doesn't feel perfect, but I couldn't come up with a neater way.