### PR TITLE
Support other monads than just IO.

### DIFF
--- a/src/Servant/Server.hs
+++ b/src/Servant/Server.hs
@@ -12,6 +12,7 @@ module Servant.Server
 
   , -- * Handlers for all standard combinators
     HasServer(..)
+  , Server
   ) where
 
 import Data.Proxy (Proxy)


### PR DESCRIPTION
I played a bit around with servant, but I need a different base monad (there already exists issue #11 that looks similar). Adding generic `MonadIO` support turned out to be quite easy (actually easy enough that I decided it's easiest to just go ahead and make a pull request).

The HasServer typeclass is modified to take a monad argument. The type family is renamed to ServerT and also takes a monad argument. `Server api` is a type alias for `ServerT api IO`, preserving backwards compatibility.

The only slight issue is around the Raw API. I had to change the type there from `Application` to `Request -> (Response -> m ResponseReceived) -> m ResponseReceived` (which is equal to `Application` if `m ~ IO`). That in turn requires a slightly awkward variant of the `serveDirectory` function that works with arbitrary monads. But I don't really see a better way out of this...

Comments?