### PR TITLE
Change JSON-specific error message to a more general one

### DIFF
--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -71,7 +71,7 @@ toApplication ra request respond = do
   routingRespond (Left WrongMethod) =
     respond $ responseLBS methodNotAllowed405 [] "method not allowed"
   routingRespond (Left (InvalidBody err)) =
-    respond $ responseLBS badRequest400 [] $ fromString $ "Invalid JSON in request body: " ++ err
+    respond $ responseLBS badRequest400 [] $ fromString $ "invalid request body: " ++ err
   routingRespond (Left UnsupportedMediaType) =
     respond $ responseLBS unsupportedMediaType415 [] "unsupported media type"
   routingRespond (Left (HttpError status body)) =


### PR DESCRIPTION
Trivial fix for a problem I found whilst doing form encoding. JSON is no longer assumed as the request format and thus the current error message can be misleading.