### PR TITLE
Canonicalize types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for the `Patch` combinator
 * Support for `Accept`/`Content-type` headers and for the content-type aware combinators in *servant-0.3*
 * Export `toApplication` from `Servant.Server` (https://github.com/haskell-servant/servant-server/pull/29)
+* Support other Monads than just `EitherT (Int, String) IO` (https://github.com/haskell-servant/servant-server/pull/21)
 
 0.2.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for `Accept`/`Content-type` headers and for the content-type aware combinators in *servant-0.3*
 * Export `toApplication` from `Servant.Server` (https://github.com/haskell-servant/servant-server/pull/29)
 * Support other Monads than just `EitherT (Int, String) IO` (https://github.com/haskell-servant/servant-server/pull/21)
+* Canonicalize API types before generating the handler typesy
 
 0.2.4
 -----

--- a/src/Servant/Server.hs
+++ b/src/Servant/Server.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This module lets you implement 'Server's for defined APIs. You'll
@@ -12,11 +13,12 @@ module Servant.Server
 
   , -- * Handlers for all standard combinators
     HasServer(..)
+  , Server
   ) where
 
 import Data.Proxy (Proxy)
 import Network.Wai (Application)
-
+import Servant.API (Canonicalize)
 import Servant.Server.Internal
 
 
@@ -42,5 +44,7 @@ import Servant.Server.Internal
 -- >
 -- > main :: IO ()
 -- > main = Network.Wai.Handler.Warp.run 8080 app
-serve :: HasServer layout => Proxy layout -> Server layout -> Application
-serve p server = toApplication (route p server)
+serve :: HasServer (Canonicalize layout) => Proxy layout -> Server layout -> Application
+serve p server = toApplication (route (canonicalize p) server)
+
+type Server layout = Server' (Canonicalize layout)

--- a/src/Servant/Server.hs
+++ b/src/Servant/Server.hs
@@ -18,7 +18,7 @@ module Servant.Server
 
 import Data.Proxy (Proxy)
 import Network.Wai (Application)
-import Servant.API (Canonicalize)
+import Servant.API (Canonicalize, canonicalize)
 import Servant.Server.Internal
 
 

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -163,9 +163,6 @@ class HasServer layout where
   type Server' layout :: *
   route :: Proxy layout -> Server' layout -> RoutingApplication
 
-canonicalize :: Canonicalize layout ~ t => Proxy layout -> Proxy t
-canonicalize Proxy = Proxy
-
 -- * Instances
 
 -- | A server for @a ':<|>' b@ first tries to match the request against the route

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -303,7 +303,7 @@ instance ( AllCTRender ctypes a
 
 -- '()' ==> 204 No Content
 instance HasServer (Get ctypes ()) where
-  type ServerT (Get ctypes ()) m = m ()
+  type ServerT' (Get ctypes ()) m = m ()
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodGet = do
         e <- runEitherT action
@@ -317,7 +317,7 @@ instance HasServer (Get ctypes ()) where
 
 -- Add response headers
 instance ( AllCTRender ctypes v ) => HasServer (Get ctypes (Headers h v)) where
-  type ServerT (Get ctypes (Headers h v)) m = m (Headers h v)
+  type ServerT' (Get ctypes (Headers h v)) m = m (Headers h v)
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodGet = do
       e <- runEitherT action
@@ -402,7 +402,7 @@ instance ( AllCTRender ctypes a
     | otherwise = respond $ failWith NotFound
 
 instance HasServer (Post ctypes ()) where
-  type ServerT (Post ctypes ()) m = m ()
+  type ServerT' (Post ctypes ()) m = m ()
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
         e <- runEitherT action
@@ -416,7 +416,7 @@ instance HasServer (Post ctypes ()) where
 
 -- Add response headers
 instance ( AllCTRender ctypes v ) => HasServer (Post ctypes (Headers h v)) where
-  type ServerT (Post ctypes (Headers h v)) m = m (Headers h v)
+  type ServerT' (Post ctypes (Headers h v)) m = m (Headers h v)
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
       e <- runEitherT action
@@ -469,7 +469,7 @@ instance ( AllCTRender ctypes a
     | otherwise = respond $ failWith NotFound
 
 instance HasServer (Put ctypes ()) where
-  type ServerT (Put ctypes ()) m = m ()
+  type ServerT' (Put ctypes ()) m = m ()
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPut = do
         e <- runEitherT action
@@ -483,7 +483,7 @@ instance HasServer (Put ctypes ()) where
 
 -- Add response headers
 instance ( AllCTRender ctypes v ) => HasServer (Put ctypes (Headers h v)) where
-  type ServerT (Put ctypes (Headers h v)) m = m (Headers h v)
+  type ServerT' (Put ctypes (Headers h v)) m = m (Headers h v)
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPut = do
       e <- runEitherT action
@@ -533,7 +533,7 @@ instance ( AllCTRender ctypes a
     | otherwise = respond $ failWith NotFound
 
 instance HasServer (Patch ctypes ()) where
-  type ServerT (Patch ctypes ()) m = m ()
+  type ServerT' (Patch ctypes ()) m = m ()
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPatch = do
         e <- runEitherT action
@@ -547,7 +547,7 @@ instance HasServer (Patch ctypes ()) where
 
 -- Add response headers
 instance ( AllCTRender ctypes v ) => HasServer (Patch ctypes (Headers h v)) where
-  type ServerT (Patch ctypes (Headers h v)) m = m (Headers h v)
+  type ServerT' (Patch ctypes (Headers h v)) m = m (Headers h v)
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPatch = do
       e <- runEitherT action

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -160,8 +160,11 @@ processedPathInfo r =
   where pinfo = parsePathInfo r
 
 class HasServer layout where
-  type Server' layout :: *
+  type ServerT layout (m :: * -> *) :: *
   route :: Proxy layout -> Server' layout -> RoutingApplication
+
+type Server' layout = ServerT layout (EitherT (Int, String) IO)
+
 
 -- * Instances
 
@@ -177,7 +180,9 @@ class HasServer layout where
 -- >   where listAllBooks = ...
 -- >         postBook book = ...
 instance (HasServer a, HasServer b) => HasServer (a :<|> b) where
-  type Server' (a :<|> b) = Server' a :<|> Server' b
+
+  type ServerT (a :<|> b) m = ServerT a m :<|> ServerT b m
+
   route Proxy (a :<|> b) request respond =
     route pa a request $ \ mResponse ->
       if isMismatch mResponse
@@ -210,8 +215,8 @@ captured _ = fromText
 instance (KnownSymbol capture, FromText a, HasServer sublayout)
       => HasServer (Capture capture a :> sublayout) where
 
-  type Server' (Capture capture a :> sublayout) =
-     a -> Server' sublayout
+  type ServerT (Capture capture a :> sublayout) m =
+     a -> ServerT sublayout m
 
   route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
@@ -237,7 +242,8 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
 -- painlessly error out if the conditions for a successful deletion
 -- are not met.
 instance HasServer Delete where
-  type Server' Delete = EitherT (Int, String) IO ()
+
+  type ServerT Delete m = m ()
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodDelete = do
@@ -266,7 +272,9 @@ instance HasServer Delete where
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Get ctypes a) where
-  type Server' (Get ctypes a) = EitherT (Int, String) IO a
+
+  type ServerT (Get ctypes a) m = m a
+
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodGet = do
         e <- runEitherT action
@@ -306,8 +314,8 @@ instance ( AllCTRender ctypes a
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (Header sym a :> sublayout) where
 
-  type Server' (Header sym a :> sublayout) =
-    Maybe a -> Server' sublayout
+  type ServerT (Header sym a :> sublayout) m =
+    Maybe a -> ServerT sublayout m
 
   route Proxy subserver request respond = do
     let mheader = fromText . decodeUtf8 =<< lookup str (requestHeaders request)
@@ -330,7 +338,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Post ctypes a) where
-  type Server' (Post ctypes a) = EitherT (Int, String) IO a
+
+  type ServerT (Post ctypes a) m = m a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
@@ -363,7 +372,8 @@ instance ( AllCTRender ctypes a
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Put ctypes a) where
-  type Server' (Put ctypes a) = EitherT (Int, String) IO a
+
+  type ServerT (Put ctypes a) m = m a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPut = do
@@ -396,7 +406,8 @@ instance ( AllCTRender ctypes a
 instance ( AllCTRender ctypes a
          , Typeable a
          , ToJSON a) => HasServer (Patch ctypes a) where
-  type Server' (Patch ctypes a) = EitherT (Int, String) IO a
+
+  type ServerT (Patch ctypes a) m = m a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
@@ -440,8 +451,8 @@ instance ( AllCTRender ctypes a
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (QueryParam sym a :> sublayout) where
 
-  type Server' (QueryParam sym a :> sublayout) =
-    Maybe a -> Server' sublayout
+  type ServerT (QueryParam sym a :> sublayout) m =
+    Maybe a -> ServerT sublayout m
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -478,8 +489,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (QueryParams sym a :> sublayout) where
 
-  type Server' (QueryParams sym a :> sublayout) =
-    [a] -> Server' sublayout
+  type ServerT (QueryParams sym a :> sublayout) m =
+    [a] -> ServerT sublayout m
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -511,8 +522,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, HasServer sublayout)
       => HasServer (QueryFlag sym :> sublayout) where
 
-  type Server' (QueryFlag sym :> sublayout) =
-    Bool -> Server' sublayout
+  type ServerT (QueryFlag sym :> sublayout) m =
+    Bool -> ServerT sublayout m
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -554,8 +565,8 @@ parseMatrixText = parseQueryText
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (MatrixParam sym a :> sublayout) where
 
-  type Server' (MatrixParam sym a :> sublayout) =
-    Maybe a -> Server' sublayout
+  type ServerT (MatrixParam sym a :> sublayout) m =
+    Maybe a -> ServerT sublayout m
 
   route Proxy subserver request respond = case parsePathInfo request of
     (first : _)
@@ -592,8 +603,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (MatrixParams sym a :> sublayout) where
 
-  type Server' (MatrixParams sym a :> sublayout) =
-    [a] -> Server' sublayout
+  type ServerT (MatrixParams sym a :> sublayout) m =
+    [a] -> ServerT sublayout m
 
   route Proxy subserver request respond = case parsePathInfo request of
     (first : _)
@@ -626,8 +637,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, HasServer sublayout)
       => HasServer (MatrixFlag sym :> sublayout) where
 
-  type Server' (MatrixFlag sym :> sublayout) =
-    Bool -> Server' sublayout
+  type ServerT (MatrixFlag sym :> sublayout) m =
+    Bool -> ServerT sublayout m
 
   route Proxy subserver request respond =  case parsePathInfo request of
     (first : _)
@@ -654,7 +665,9 @@ instance (KnownSymbol sym, HasServer sublayout)
 -- > server :: Server MyApi
 -- > server = serveDirectory "/var/www/images"
 instance HasServer Raw where
-  type Server' Raw = Application
+
+  type ServerT Raw m = Application
+
   route Proxy rawApplication request respond =
     rawApplication request (respond . succeedWith)
 
@@ -681,8 +694,8 @@ instance HasServer Raw where
 instance ( AllCTUnrender list a, HasServer sublayout
          ) => HasServer (ReqBody list a :> sublayout) where
 
-  type Server' (ReqBody list a :> sublayout) =
-    a -> Server' sublayout
+  type ServerT (ReqBody list a :> sublayout) m =
+    a -> ServerT sublayout m
 
   route Proxy subserver request respond = do
     -- See HTTP RFC 2616, section 7.2.1
@@ -701,7 +714,9 @@ instance ( AllCTUnrender list a, HasServer sublayout
 -- | Make sure the incoming request starts with @"/path"@, strip it and
 -- pass the rest of the request path to @sublayout@.
 instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout) where
-  type Server' (path :> sublayout) = Server' sublayout
+
+  type ServerT (path :> sublayout) m = ServerT sublayout m
+
   route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
       | first == cs (symbolVal proxyPath)

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -160,10 +160,11 @@ processedPathInfo r =
   where pinfo = parsePathInfo r
 
 class HasServer layout where
-  type Server layout :: *
-  route :: Proxy layout -> Server layout -> RoutingApplication
+  type Server' layout :: *
+  route :: Proxy layout -> Server' layout -> RoutingApplication
 
-
+canonicalize :: Canonicalize layout ~ t => Proxy layout -> Proxy t
+canonicalize Proxy = Proxy
 
 -- * Instances
 
@@ -179,7 +180,7 @@ class HasServer layout where
 -- >   where listAllBooks = ...
 -- >         postBook book = ...
 instance (HasServer a, HasServer b) => HasServer (a :<|> b) where
-  type Server (a :<|> b) = Server a :<|> Server b
+  type Server' (a :<|> b) = Server' a :<|> Server' b
   route Proxy (a :<|> b) request respond =
     route pa a request $ \ mResponse ->
       if isMismatch mResponse
@@ -212,8 +213,8 @@ captured _ = fromText
 instance (KnownSymbol capture, FromText a, HasServer sublayout)
       => HasServer (Capture capture a :> sublayout) where
 
-  type Server (Capture capture a :> sublayout) =
-     a -> Server sublayout
+  type Server' (Capture capture a :> sublayout) =
+     a -> Server' sublayout
 
   route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
@@ -239,7 +240,7 @@ instance (KnownSymbol capture, FromText a, HasServer sublayout)
 -- painlessly error out if the conditions for a successful deletion
 -- are not met.
 instance HasServer Delete where
-  type Server Delete = EitherT (Int, String) IO ()
+  type Server' Delete = EitherT (Int, String) IO ()
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodDelete = do
@@ -268,7 +269,7 @@ instance HasServer Delete where
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Get ctypes a) where
-  type Server (Get ctypes a) = EitherT (Int, String) IO a
+  type Server' (Get ctypes a) = EitherT (Int, String) IO a
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodGet = do
         e <- runEitherT action
@@ -308,8 +309,8 @@ instance ( AllCTRender ctypes a
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (Header sym a :> sublayout) where
 
-  type Server (Header sym a :> sublayout) =
-    Maybe a -> Server sublayout
+  type Server' (Header sym a :> sublayout) =
+    Maybe a -> Server' sublayout
 
   route Proxy subserver request respond = do
     let mheader = fromText . decodeUtf8 =<< lookup str (requestHeaders request)
@@ -332,7 +333,7 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Post ctypes a) where
-  type Server (Post ctypes a) = EitherT (Int, String) IO a
+  type Server' (Post ctypes a) = EitherT (Int, String) IO a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
@@ -365,7 +366,7 @@ instance ( AllCTRender ctypes a
 -- list.
 instance ( AllCTRender ctypes a
          ) => HasServer (Put ctypes a) where
-  type Server (Put ctypes a) = EitherT (Int, String) IO a
+  type Server' (Put ctypes a) = EitherT (Int, String) IO a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPut = do
@@ -398,7 +399,7 @@ instance ( AllCTRender ctypes a
 instance ( AllCTRender ctypes a
          , Typeable a
          , ToJSON a) => HasServer (Patch ctypes a) where
-  type Server (Patch ctypes a) = EitherT (Int, String) IO a
+  type Server' (Patch ctypes a) = EitherT (Int, String) IO a
 
   route Proxy action request respond
     | pathIsEmpty request && requestMethod request == methodPost = do
@@ -442,8 +443,8 @@ instance ( AllCTRender ctypes a
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (QueryParam sym a :> sublayout) where
 
-  type Server (QueryParam sym a :> sublayout) =
-    Maybe a -> Server sublayout
+  type Server' (QueryParam sym a :> sublayout) =
+    Maybe a -> Server' sublayout
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -480,8 +481,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (QueryParams sym a :> sublayout) where
 
-  type Server (QueryParams sym a :> sublayout) =
-    [a] -> Server sublayout
+  type Server' (QueryParams sym a :> sublayout) =
+    [a] -> Server' sublayout
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -513,8 +514,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, HasServer sublayout)
       => HasServer (QueryFlag sym :> sublayout) where
 
-  type Server (QueryFlag sym :> sublayout) =
-    Bool -> Server sublayout
+  type Server' (QueryFlag sym :> sublayout) =
+    Bool -> Server' sublayout
 
   route Proxy subserver request respond = do
     let querytext = parseQueryText $ rawQueryString request
@@ -556,8 +557,8 @@ parseMatrixText = parseQueryText
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (MatrixParam sym a :> sublayout) where
 
-  type Server (MatrixParam sym a :> sublayout) =
-    Maybe a -> Server sublayout
+  type Server' (MatrixParam sym a :> sublayout) =
+    Maybe a -> Server' sublayout
 
   route Proxy subserver request respond = case parsePathInfo request of
     (first : _)
@@ -594,8 +595,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, FromText a, HasServer sublayout)
       => HasServer (MatrixParams sym a :> sublayout) where
 
-  type Server (MatrixParams sym a :> sublayout) =
-    [a] -> Server sublayout
+  type Server' (MatrixParams sym a :> sublayout) =
+    [a] -> Server' sublayout
 
   route Proxy subserver request respond = case parsePathInfo request of
     (first : _)
@@ -628,8 +629,8 @@ instance (KnownSymbol sym, FromText a, HasServer sublayout)
 instance (KnownSymbol sym, HasServer sublayout)
       => HasServer (MatrixFlag sym :> sublayout) where
 
-  type Server (MatrixFlag sym :> sublayout) =
-    Bool -> Server sublayout
+  type Server' (MatrixFlag sym :> sublayout) =
+    Bool -> Server' sublayout
 
   route Proxy subserver request respond =  case parsePathInfo request of
     (first : _)
@@ -656,7 +657,7 @@ instance (KnownSymbol sym, HasServer sublayout)
 -- > server :: Server MyApi
 -- > server = serveDirectory "/var/www/images"
 instance HasServer Raw where
-  type Server Raw = Application
+  type Server' Raw = Application
   route Proxy rawApplication request respond =
     rawApplication request (respond . succeedWith)
 
@@ -683,8 +684,8 @@ instance HasServer Raw where
 instance ( AllCTUnrender list a, HasServer sublayout
          ) => HasServer (ReqBody list a :> sublayout) where
 
-  type Server (ReqBody list a :> sublayout) =
-    a -> Server sublayout
+  type Server' (ReqBody list a :> sublayout) =
+    a -> Server' sublayout
 
   route Proxy subserver request respond = do
     -- See HTTP RFC 2616, section 7.2.1
@@ -703,7 +704,7 @@ instance ( AllCTUnrender list a, HasServer sublayout
 -- | Make sure the incoming request starts with @"/path"@, strip it and
 -- pass the rest of the request path to @sublayout@.
 instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout) where
-  type Server (path :> sublayout) = Server sublayout
+  type Server' (path :> sublayout) = Server' sublayout
   route Proxy subserver request respond = case processedPathInfo request of
     (first : rest)
       | first == cs (symbolVal proxyPath)

--- a/src/Servant/Server/Internal.hs
+++ b/src/Servant/Server/Internal.hs
@@ -165,7 +165,6 @@ class HasServer layout where
 
 type Server' layout = ServerT layout (EitherT (Int, String) IO)
 
-
 -- * Instances
 
 -- | A server for @a ':<|>' b@ first tries to match the request against the route
@@ -184,7 +183,7 @@ instance (HasServer a, HasServer b) => HasServer (a :<|> b) where
   type ServerT (a :<|> b) m = ServerT a m :<|> ServerT b m
 
   route Proxy (a :<|> b) request respond =
-    route pa a request $ \ mResponse ->
+    route pa a request $ \mResponse ->
       if isMismatch mResponse
         then route pb b request $ \mResponse' -> respond (mResponse <> mResponse')
         else respond mResponse

--- a/src/Servant/Utils/StaticFiles.hs
+++ b/src/Servant/Utils/StaticFiles.hs
@@ -9,7 +9,7 @@ module Servant.Utils.StaticFiles (
 import Filesystem.Path.CurrentOS (decodeString)
 import Network.Wai.Application.Static (staticApp, defaultFileServerSettings)
 import Servant.API.Raw (Raw)
-import Servant.Server.Internal (Server)
+import Servant.Server (Server)
 
 -- | Serve anything under the specified directory as a 'Raw' endpoint.
 --


### PR DESCRIPTION
See haskell-servant/servant#23. This runs `Canonicalize` on the API type to flatten all arguments and distribute them to each handlers. Basically makes sure this holds:

``` haskell
Server (a :<|> b) = Server a :<|> Server b -- this one already holds
Server (a :> (b :<|> c)) = Server (a :> b) :<|> Server (a :> c) -- this one doesn't
```

Other PRs:
- haskell-servant/servant#23
- haskell-servant/servant-client#15
- haskell-servant/servant-jquery#10
- haskell-servant/servant-docs#16
